### PR TITLE
Fix repeated kwarg issue in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ plugin_author = "Paul de Vries"
 plugin_author_email = "pablo+octoprint+touch+ui@aerosol.me"
 plugin_url = "https://github.com/BillyBlaze/OctoPrint-TouchUI"
 plugin_license = "AGPLv3"
-plugin_requires = []
+plugin_requires = ["OctoPrint>=1.2.4"]
 plugin_additional_data = []
 plugin_addtional_packages = []
 plugin_ignored_packages = []
@@ -38,10 +38,7 @@ setup_parameters = octoprint_setuptools.create_plugin_setup_parameters(
 	requires=plugin_requires,
 	additional_packages=plugin_addtional_packages,
 	ignored_packages=plugin_ignored_packages,
-	additional_data=plugin_additional_data,
-	requires=[
-		"OctoPrint>=1.2.4"
-	]
+	additional_data=plugin_additional_data
 )
 
 if len(additional_setup_parameters):


### PR DESCRIPTION
`requires` was already set in the call, causing issues when
trying to install that plugin.

Setting `plugin_requires` in the configuration section of 
`setup.py` instead and removing the second `requires`
parameter fixes that.
