### PR TITLE
Add PSUControl on/off class

### DIFF
--- a/source/less/plugins/psucontrol.less
+++ b/source/less/plugins/psucontrol.less
@@ -1,3 +1,13 @@
-#navbar .navbar-inner .container .nav li.dropdown#all_touchui_settings li #psucontrol_indicator:before {
-	content: '\f0e7';
+#navbar .navbar-inner .container .nav li.dropdown#all_touchui_settings li #psucontrol_indicator {
+    &:before {
+        content: '\f0e7';
+    }
+
+    &.on {
+        color: #00FF00;
+    }
+
+    &.off {
+        color: #808080;
+    }
 }


### PR DESCRIPTION
I've switched from setting the color property directly to instead using classes in an upcoming release. It is backwards compatible.

Also note that I did not compile or bundle the files as I cannot seem to get the utils to work on my env at this time.