### PR TITLE
Adapt control moving to OctoPrint 1.4.1

### DIFF
--- a/source/js/dom/move/controls.js
+++ b/source/js/dom/move/controls.js
@@ -18,10 +18,20 @@ TouchUI.prototype.DOM.move.controls = {
 
 		}
 
-		$("#control-jog-feedrate").insertBefore("#control-jog-extrusion");
-		$("#control-jog-extrusion button:last-child").prependTo("#control-jog-feedrate");
-		$("#control-jog-extrusion input:last-child").attr('data-bind', $("#control-jog-extrusion input:last-child").attr('data-bind').replace('slider: {', 'slider: {tools: tools(), ')).prependTo("#control-jog-feedrate");
-		$("#control-jog-extrusion .slider:last-child").prependTo("#control-jog-feedrate");
+		if($('#control-jog-feedrate .input-append').length === 0) {
+			// <1.4.1
+			$("#control-jog-feedrate").insertBefore("#control-jog-extrusion");
+			$("#control-jog-extrusion button:last-child").prependTo("#control-jog-feedrate");
+			$("#control-jog-extrusion input:last-child").attr('data-bind', $("#control-jog-extrusion input:last-child").attr('data-bind').replace('slider: {', 'slider: {tools: tools(), ')).prependTo("#control-jog-feedrate");
+			$("#control-jog-extrusion .slider:last-child").prependTo("#control-jog-feedrate");
+		} else {
+			// >=1.4.1
+			$("#control-jog-feedrate").insertBefore("#control-jog-extrusion");
+			$("#control-jog-feedrate .input-append button").insertAfter("#control-jog-feedrate .input-append");
+
+			$("#control-jog-flowrate").removeClass("jog-panel");
+			$("#control-jog-flowrate .input-append button").insertAfter("#control-jog-flowrate .input-append");
+		}
 
 		$("#control div.distance").prependTo("#control-jog-feedrate");
 	}


### PR DESCRIPTION
Feedrate/flowrate controls have been changed, making the old implementation
fail with a JS error. This works around that.

Note: 1.4.1rc3 still has a duplicated id here (`control-jog-feedrate` exists twice,
second one should be `control-jog-flowrate`), I'll change that for the stable final
release.

Closes #413 